### PR TITLE
Support Node versions down to 0.10

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    "transform-es2015-template-literals",
+    "transform-es2015-arrow-functions",
+    "transform-es2015-constants",
+    "transform-es2015-block-scoping"
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 *.log
 *.log.*
+dist/
+test-es5/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
 node_js:
+  - "0.10"
+  - "0.12"
   - "4"
   - "5"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 environment:
   matrix:
+    - nodejs_version: "0.10"
+    - nodejs_version: "0.12"
     - nodejs_version: "4"
     - nodejs_version: "5"
 install:

--- a/package.json
+++ b/package.json
@@ -2,9 +2,13 @@
   "name": "command-join",
   "version": "1.0.1",
   "description": "Escape and join command-line arguments, cross-platform.",
-  "main": "command-join.js",
+  "main": "dist/command-join.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
-    "test": "mocha test/*.test.js"
+    "build": "babel command-join.js --out-dir dist && babel test --out-dir test-es5",
+    "test": "npm run build && mocha test-es5/*.test.js"
   },
   "repository": {
     "type": "git",
@@ -25,10 +29,20 @@
   },
   "homepage": "https://github.com/seangenabe/command-join#readme",
   "devDependencies": {
+    "babel-cli": "^6.14.0",
+    "babel-core": "^6.14.0",
+    "babel-plugin-transform-es2015-arrow-functions": "^6.8.0",
+    "babel-plugin-transform-es2015-block-scoping": "^6.15.0",
+    "babel-plugin-transform-es2015-constants": "^6.1.4",
+    "babel-plugin-transform-es2015-template-literals": "^6.8.0",
     "chai": "^3.4.1",
     "mocha": "^2.3.4"
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=0.10"
+  },
+  "dependencies": {
+    "array-from": "^2.1.1",
+    "repeat-string": "^1.5.4"
   }
 }

--- a/test/exec.js
+++ b/test/exec.js
@@ -1,12 +1,12 @@
 'use strict'
 
-const join = require('..')
+const join = require('../')
 const ChildProcess = require('child_process')
 
 if (require.main === module) {
   console.log(process.argv.slice(2).join('\n'))
 }
-else {
+else if (typeof ChildProcess.execSync === 'function') {
   module.exports = function exec(args) {
     args = args.slice()
     args.unshift(__filename)

--- a/test/nix.test.js
+++ b/test/nix.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const join = require('..')
+const join = require('../')
 const expect = require('chai').expect
 const exec = require('./exec')
 
@@ -16,12 +16,14 @@ describe('nix tests', function() {
     expect(join(commands1)).to.equal('a b c d.txt')
   })
 
-  it('should exec normally', function() {
-    expect(exec(commands1)).to.equal(commands1.join('\n'))
-  })
+  if (typeof exec === 'function') {
+    it('should exec normally', function() {
+        expect(exec(commands1)).to.equal(commands1.join('\n'))
+    })
 
-  it('should exec string with single quotes', function() {
-    expect(exec(commands2)).to.equal(commands2.join('\n'))
-  })
+    it('should exec string with single quotes', function() {
+        expect(exec(commands2)).to.equal(commands2.join('\n'))
+    })
+  }
 
 })

--- a/test/win.test.js
+++ b/test/win.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const join = require('..')
+const join = require('../')
 const expect = require('chai').expect
 const exec = require('./exec')
 
@@ -16,12 +16,14 @@ describe('win32 tests', function() {
     expect(join(commands1)).to.equal("a b.txt c/d 'e'")
   })
 
-  it('should exec normally', function() {
-    expect(exec(commands1)).to.equal(commands1.join('\n'))
-  })
+  if (typeof exec === 'function') {
+    it('should exec normally', function() {
+        expect(exec(commands1)).to.equal(commands1.join('\n'))
+    })
 
-  it('should exec to escape special characters', function() {
-    expect(exec(commands2)).to.equal(commands2.join('\n'))
-  })
+    it('should exec to escape special characters', function() {
+        expect(exec(commands2)).to.equal(commands2.join('\n'))
+    })
+  }
 
 })


### PR DESCRIPTION
Hi there! I'm working on a PR for [Lerna](https://github.com/lerna/lerna) making use of command-join. Lerna is used in Babel which is still regularly tested on Node 0.10 and 0.12. This PR makes command-join compatible with those environments.

To avoid just rewriting the module in ES5, my approach was to add Babel transforms but generally avoid the bloat associated with polyfills, especially `babel-runtime`. This is the cause of the most visible change in the code, which is the use of `Array.prototype.map / forEach` in place of `for..of` (which requires a Symbol polyfill).

I hope you find this PR acceptable, as I would much rather keep using command-join over publishing a fork.
#### Details
- Add a Babel build step with a minimal set of required transforms
- Use array-from polyfill instead of Array.from
- Use repeat-string instead of String.prototype.repeat
- Make some code changes to avoid costly polyfills
- Only run exec tests where execSync is available
- Run tests on 0.10 and 0.12 too
