### PR TITLE
Quote empty strings

### DIFF
--- a/command-join.js
+++ b/command-join.js
@@ -5,6 +5,11 @@ const NEEDS_QUOTE = /[\s\\*\?\[\]`$()#<>|&;]/
 function joinNix(arr) {
   let out = []
   for (let command of arr) {
+    // if it is an empty string then skip the logic
+    if (command.length === 0) {
+      out.push("''")
+      continue
+    }
     // whether we need a quote for the current block
     let needsQuote = false
     // collection of quoted strings and escaped single quotes
@@ -46,6 +51,11 @@ function joinWin(arr) {
   let out = []
 
   for (let command of arr) {
+    // if it is an empty string then skip the logic
+    if (command.length === 0) {
+      out.push('""')
+      continue
+    }
     if (!/[\s\\"<>|&]/.test(command)) {
       out.push(command)
       continue


### PR DESCRIPTION
This PR adds quoting for empty strings.

Currently, empty strings are not quoted. This causes problems since some programs actually use empty arguments (`splitindex` for one). For example, on Linux

```javascript
commandJoin(['splitindex', '-m', '', 'foo'])
```

results in `splitindex -m  foo` with two spaces between the second and fourth argument instead of `splitindex -m '' foo`